### PR TITLE
Added support based on service_id

### DIFF
--- a/packages/cli/src/middlewares/externalJWTAuth.ts
+++ b/packages/cli/src/middlewares/externalJWTAuth.ts
@@ -11,14 +11,19 @@ function jwtAuthAuthorizationError(resp: Response, message?: string) {
 interface QpJwt {
 	gcip: {
 		x_qp_entitlements: {
-			allowed_products: Array<{
-				datastudio: string;
-				product_id: string;
-				storefront: string;
-				workflow: string; // n8n User
-			}>;
-			is_super_admin: boolean;
-			is_service_admin: boolean;
+			api_roles: string[];
+			is_workflow_user_per_service: boolean;
+			workflow: string; // n8n User once per tenant
+			qp_user_id: string;
+			service_id: string;
+			// allowed_products: Array<{
+			// 	datastudio: string;
+			// 	product_id: string;
+			// 	storefront: string;
+			// 	workflow: string; // n8n User
+			// }>;
+			//is_super_admin: boolean;
+			//is_service_admin: boolean;
 		};
 	};
 }


### PR DESCRIPTION
Cogeco - n8n - Support for authentication based on serviceId

**New token format**

```
{
  "name": "Ajith Kumar",
  "x_qp_entitlements": {
    "api_roles": [
      "cms-default"
    ],
    "is_workflow_user_per_service": true,
    "qp_user_id": "e29eb34a-dc08-4731-8bc1-5e2bae4da8f5",
    "service_id": "06cf008c-6112-43a8-9e41-10a9e1d32d3d",
    "workflow": "cogecoml"
  },
  "x-qp-refresh-allowed": false,
 
}
```


Changes:

CMS removed the allowed_products from the token. Instead, the workflow information will now be found under the x_qp_entitlements section.