### PR TITLE
VE-11060 - Upgrade to n8n v1.79.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.79.3](https://github.com/n8n-io/n8n/compare/n8n@1.79.2...n8n@1.79.3) (2025-02-21)
+
+
+### Bug Fixes
+
+* **core:** Make sure middleware works with legacy API Keys ([#13390](https://github.com/n8n-io/n8n/issues/13390)) ([537df8a](https://github.com/n8n-io/n8n/commit/537df8a745ec4956da9898593c962d16e2d4097b))
+
+
+
 ## [1.79.2](https://github.com/n8n-io/n8n/compare/n8n@1.79.1...n8n@1.79.2) (2025-02-20)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-monorepo",
-  "version": "1.79.2",
+  "version": "1.79.3",
   "private": true,
   "engines": {
     "node": ">=20.15",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n",
-  "version": "1.79.2",
+  "version": "1.79.3",
   "description": "n8n Workflow Automation Tool",
   "main": "dist/index",
   "types": "dist/index.d.ts",

--- a/packages/cli/test/integration/shared/db/users.ts
+++ b/packages/cli/test/integration/shared/db/users.ts
@@ -80,23 +80,30 @@ export async function createUserWithMfaEnabled(
 	};
 }
 
-export const addApiKey = async (user: User) => {
+export const addApiKey = async (
+	user: User,
+	{ expiresAt = null }: { expiresAt?: number | null } = {},
+) => {
 	return await Container.get(PublicApiKeyService).createPublicApiKeyForUser(user, {
 		label: randomName(),
-		expiresAt: null,
+		expiresAt,
 	});
 };
 
-export async function createOwnerWithApiKey() {
+export async function createOwnerWithApiKey({
+	expiresAt = null,
+}: { expiresAt?: number | null } = {}) {
 	const owner = await createOwner();
-	const apiKey = await addApiKey(owner);
+	const apiKey = await addApiKey(owner, { expiresAt });
 	owner.apiKeys = [apiKey];
 	return owner;
 }
 
-export async function createMemberWithApiKey() {
+export async function createMemberWithApiKey({
+	expiresAt = null,
+}: { expiresAt?: number | null } = {}) {
 	const member = await createMember();
-	const apiKey = await addApiKey(member);
+	const apiKey = await addApiKey(member, { expiresAt });
 	member.apiKeys = [apiKey];
 	return member;
 }

--- a/packages/core/src/nodes-loader/directory-loader.ts
+++ b/packages/core/src/nodes-loader/directory-loader.ts
@@ -366,6 +366,14 @@ export abstract class DirectoryLoader {
 	}
 
 	private getIconPath(icon: string, filePath: string) {
+		// For custom nodes, strip the base path to make it relative
+		if (this.packageName === 'CUSTOM') {
+			const relativePath = path.relative(this.directory, filePath);
+			const iconPath = path.join(path.dirname(relativePath), icon.replace('file:', ''));
+			return `icons/${this.packageName}/${iconPath}`;
+		}
+
+		// Original behavior for non-custom nodes
 		const iconPath = path.join(path.dirname(filePath), icon.replace('file:', ''));
 		return `icons/${this.packageName}/${iconPath}`;
 	}

--- a/quickplay/readme.md
+++ b/quickplay/readme.md
@@ -37,7 +37,7 @@ git fetch upstream --tags
 git checkout master
 git pull
 git checkout feature/VE-11060
-git merge tags/n8n@1.79.1
+git merge tags/n8n@1.79.3
 ```
 
 Resolving Merge conflicts:


### PR DESCRIPTION
VE-11060 
- Upgrade to n8n v1.79.3
- Fix the path loader for custom icons

```
  private getIconPath(icon: string, filePath: string) {
    // For custom nodes, strip the base path to make it relative
    if (this.packageName === 'CUSTOM') {
	    const relativePath = path.relative(this.directory, filePath);
	    const iconPath = path.join(path.dirname(relativePath), icon.replace('file:', ''));
	    return `icons/${this.packageName}/${iconPath}`;
    }
    
    // Original behavior for non-custom nodes
    const iconPath = path.join(path.dirname(filePath), icon.replace('file:', ''));
    return `icons/${this.packageName}/${iconPath}`;
	}
```
